### PR TITLE
chore(security): sync dependency security overrides

### DIFF
--- a/gradle/security-overrides.properties
+++ b/gradle/security-overrides.properties
@@ -2,13 +2,7 @@
 # Source: GitHub Dependabot open alerts (maven ecosystem).
 # Regenerate: scripts/sync_security_overrides.sh
 
-io.netty:netty-codec=4.2.5.Final
-io.netty:netty-codec-http=4.2.13.Final
-io.netty:netty-codec-http2=4.2.11.Final
-io.netty:netty-common=4.1.118.Final
-io.netty:netty-handler=4.1.118.Final
 org.apache.commons:commons-lang3=3.18.0
-org.apache.httpcomponents:httpclient=5.0.3
 org.bitbucket.b_c:jose4j=0.9.6
 org.bouncycastle:bcpkix-jdk18on=1.84
 org.bouncycastle:bcprov-jdk18on=1.84


### PR DESCRIPTION
Automated sync of dependency security overrides from GitHub Dependabot open alerts.
- Add new forced versions for newly detected vulnerable packages
- Remove obsolete overrides when alerts are resolved upstream

## Summary by Sourcery

Build:
- 刷新依赖项安全覆盖配置，移除已过时且不再需要的 Netty 和 HttpClient 强制版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Refresh dependency security override properties to remove outdated Netty and HttpClient forced versions no longer required.

</details>